### PR TITLE
Forward Java log configuration to Rust log subscriber

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,11 @@ As an example, to configure `slf4j-simple`, you can do:
    System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", "debug");
 ```
 
+You can then log through the `Runtime` API:
+```java
+   Runtime.getLogger().log("info", "myClass", "Hello World");
+```
+
 # License
 
 This project is licensed under either of

--- a/README.md
+++ b/README.md
@@ -114,7 +114,12 @@ public class Echo {
 ```
 
 ## Configuring Logging
-Set `NGROK_LOG_LEVEL` environment variable to adjust logging level. Valid values are `TRACE`, `DEBUG`, `INFO`, `WARN`, and `ERROR`. Defaults to `INFO`.
+Log level is set from the your `slf4j` implementation's configuration. This level must be assigned before creating a session, as it is read on creation.
+
+As an example, to configure `slf4j-simple`, you can do:
+```java
+   System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", "debug");
+```
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Log level is set from the your `slf4j` implementation's configuration. This leve
 
 As an example, to configure `slf4j-simple`, you can do:
 ```java
-   System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", "debug");
+   System.setProperty("org.slf4j.simpleLogger.log.com.ngrok.Runtime", "debug");
 ```
 
 You can then log through the `Runtime` API:

--- a/README.md
+++ b/README.md
@@ -73,8 +73,7 @@ For example of how to setup your project, check out [ngrok-java-demo](https://gi
 
 # Documentation
 
-# Quickstart
-
+## Quickstart
 
 ```java
 import com.ngrok.Session;
@@ -113,6 +112,9 @@ public class Echo {
    }
 }
 ```
+
+## Configuring Logging
+Set `NGROK_LOG_LEVEL` environment variable to adjust logging level. Valid values are `TRACE`, `DEBUG`, `INFO`, `WARN`, and `ERROR`. Defaults to `INFO`.
 
 # License
 

--- a/ngrok-java-native/pom.xml
+++ b/ngrok-java-native/pom.xml
@@ -23,6 +23,12 @@
             <version>${slf4j.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>

--- a/ngrok-java-native/src/lib.rs
+++ b/ngrok-java-native/src/lib.rs
@@ -69,7 +69,8 @@ impl<'local> com_ngrok::RuntimeRs<'local> for RuntimeRsImpl<'local> {
                     .expect("cannot get logger ref");
                 LOGGER.get_or_init(|| logref);
 
-                let log_lvl: Level = Level::from_str(&logger.get_level(self.env)).expect("invalid log level");
+                let log_lvl: Level =
+                    Level::from_str(&logger.get_level(self.env)).expect("invalid log level");
                 let level_filter: LevelFilter = log_lvl.into();
                 tracing_subscriber::registry()
                     .with(TracingLoggingLayer)

--- a/ngrok-java-native/src/lib.rs
+++ b/ngrok-java-native/src/lib.rs
@@ -73,7 +73,7 @@ impl<'local> com_ngrok::RuntimeRs<'local> for RuntimeRsImpl<'local> {
                     .expect("cannot attach");
 
                 let log_lvl: Level =
-                    Level::from_str(&logger.get_level_str(jenv)).unwrap_or(Level::TRACE);
+                    Level::from_str(&logger.get_level(jenv)).unwrap_or(Level::TRACE);
                 let level_filter: LevelFilter = log_lvl.into();
                 tracing_subscriber::registry()
                     .with(TracingLoggingLayer)

--- a/ngrok-java-native/src/lib.rs
+++ b/ngrok-java-native/src/lib.rs
@@ -70,7 +70,7 @@ impl<'local> com_ngrok::RuntimeRs<'local> for RuntimeRsImpl<'local> {
                 LOGGER.get_or_init(|| logref);
 
                 let log_lvl: Level =
-                    Level::from_str(&logger.get_level(self.env)).unwrap_or(Level::TRACE);
+                    Level::from_str(&logger.get_level(self.env)).unwrap();
                 let level_filter: LevelFilter = log_lvl.into();
                 tracing_subscriber::registry()
                     .with(TracingLoggingLayer)

--- a/ngrok-java-native/src/lib.rs
+++ b/ngrok-java-native/src/lib.rs
@@ -13,7 +13,7 @@ use futures::TryStreamExt;
 use once_cell::sync::OnceCell;
 use std::{str::FromStr, sync::MutexGuard, time::Duration};
 use tokio::{io::AsyncReadExt, io::AsyncWriteExt, runtime::Runtime};
-use tracing::{Level, level_filters::LevelFilter};
+use tracing::{level_filters::LevelFilter, Level};
 use tracing_subscriber::{prelude::__tracing_subscriber_SubscriberExt, util::SubscriberInitExt};
 
 use jaffi_support::{
@@ -72,8 +72,9 @@ impl<'local> com_ngrok::RuntimeRs<'local> for RuntimeRsImpl<'local> {
                     .attach_current_thread_as_daemon()
                     .expect("cannot attach");
 
-                let log_lvl: Level = Level::from_str(&logger.get_level_str(jenv)).unwrap_or(Level::TRACE);
-                let level_filter: LevelFilter = log_lvl.into(); 
+                let log_lvl: Level =
+                    Level::from_str(&logger.get_level_str(jenv)).unwrap_or(Level::TRACE);
+                let level_filter: LevelFilter = log_lvl.into();
                 tracing_subscriber::registry()
                     .with(TracingLoggingLayer)
                     .with(level_filter)

--- a/ngrok-java-native/src/lib.rs
+++ b/ngrok-java-native/src/lib.rs
@@ -13,7 +13,7 @@ use futures::TryStreamExt;
 use once_cell::sync::OnceCell;
 use std::{str::FromStr, sync::MutexGuard, time::Duration};
 use tokio::{io::AsyncReadExt, io::AsyncWriteExt, runtime::Runtime};
-use tracing::metadata::LevelFilter;
+use tracing::Level;
 use tracing_subscriber::{prelude::__tracing_subscriber_SubscriberExt, util::SubscriberInitExt};
 
 use jaffi_support::{
@@ -69,9 +69,11 @@ impl<'local> com_ngrok::RuntimeRs<'local> for RuntimeRsImpl<'local> {
                     .expect("cannot get logger ref");
                 LOGGER.get_or_init(|| logref);
 
+                let logLvl: Level = Level::from_str(logger.getLevelStr()).unwrap_or(Level::TRACE);
+                let levelFilter: LevelFilter = logLvl.into(); 
                 tracing_subscriber::registry()
                     .with(TracingLoggingLayer)
-                    .with(LevelFilter::TRACE)
+                    .with(levelFilter)
                     .try_init()
                     .expect("cannot init logging");
             }

--- a/ngrok-java-native/src/lib.rs
+++ b/ngrok-java-native/src/lib.rs
@@ -69,7 +69,7 @@ impl<'local> com_ngrok::RuntimeRs<'local> for RuntimeRsImpl<'local> {
                     .expect("cannot get logger ref");
                 LOGGER.get_or_init(|| logref);
 
-                let log_lvl: Level = Level::from_str(&logger.get_level(self.env)).unwrap();
+                let log_lvl: Level = Level::from_str(&logger.get_level(self.env)).expect("invalid log level");
                 let level_filter: LevelFilter = log_lvl.into();
                 tracing_subscriber::registry()
                     .with(TracingLoggingLayer)

--- a/ngrok-java-native/src/lib.rs
+++ b/ngrok-java-native/src/lib.rs
@@ -69,8 +69,7 @@ impl<'local> com_ngrok::RuntimeRs<'local> for RuntimeRsImpl<'local> {
                     .expect("cannot get logger ref");
                 LOGGER.get_or_init(|| logref);
 
-                let log_lvl: Level =
-                    Level::from_str(&logger.get_level(self.env)).unwrap();
+                let log_lvl: Level = Level::from_str(&logger.get_level(self.env)).unwrap();
                 let level_filter: LevelFilter = log_lvl.into();
                 tracing_subscriber::registry()
                     .with(TracingLoggingLayer)

--- a/ngrok-java-native/src/lib.rs
+++ b/ngrok-java-native/src/lib.rs
@@ -61,6 +61,7 @@ impl<'local> com_ngrok::RuntimeRs<'local> for RuntimeRsImpl<'local> {
                 RT.get_or_init(|| rt);
 
                 let jvm = self.env.get_java_vm().expect("cannot get jvm");
+                JVM.get_or_init(|| jvm);
 
                 let logref = self
                     .env
@@ -68,20 +69,14 @@ impl<'local> com_ngrok::RuntimeRs<'local> for RuntimeRsImpl<'local> {
                     .expect("cannot get logger ref");
                 LOGGER.get_or_init(|| logref);
 
-                let jenv = jvm
-                    .attach_current_thread_as_daemon()
-                    .expect("cannot attach");
-
                 let log_lvl: Level =
-                    Level::from_str(&logger.get_level(jenv)).unwrap_or(Level::TRACE);
+                    Level::from_str(&logger.get_level(env)).unwrap_or(Level::TRACE);
                 let level_filter: LevelFilter = log_lvl.into();
                 tracing_subscriber::registry()
                     .with(TracingLoggingLayer)
                     .with(level_filter)
                     .try_init()
                     .expect("cannot init logging");
-
-                JVM.get_or_init(|| jvm);
             }
             Err(err) => {
                 self.env

--- a/ngrok-java-native/src/lib.rs
+++ b/ngrok-java-native/src/lib.rs
@@ -70,7 +70,7 @@ impl<'local> com_ngrok::RuntimeRs<'local> for RuntimeRsImpl<'local> {
                 LOGGER.get_or_init(|| logref);
 
                 let log_lvl: Level =
-                    Level::from_str(&logger.get_level(env)).unwrap_or(Level::TRACE);
+                    Level::from_str(&logger.get_level(self.env)).unwrap_or(Level::TRACE);
                 let level_filter: LevelFilter = log_lvl.into();
                 tracing_subscriber::registry()
                     .with(TracingLoggingLayer)

--- a/ngrok-java-native/src/main/java/com/ngrok/NativeSession.java
+++ b/ngrok-java-native/src/main/java/com/ngrok/NativeSession.java
@@ -7,9 +7,10 @@ public class NativeSession implements Session {
     private static String version = "0.0.0-UNKNOWN";
 
     static {
+        Runtime.Logger logger = Runtime.Logger.Get();
         try {
             Runtime.load();
-            Runtime.init(new Runtime.Logger());
+            Runtime.init(logger);
         } catch (Throwable th) {
             // TODO better error handling here?
             th.printStackTrace();

--- a/ngrok-java-native/src/main/java/com/ngrok/NativeSession.java
+++ b/ngrok-java-native/src/main/java/com/ngrok/NativeSession.java
@@ -7,10 +7,9 @@ public class NativeSession implements Session {
     private static String version = "0.0.0-UNKNOWN";
 
     static {
-        Runtime.Logger logger = Runtime.getLogger();
         try {
             Runtime.load();
-            Runtime.init(logger);
+            Runtime.init(Runtime.getLogger());
         } catch (Throwable th) {
             // TODO better error handling here?
             th.printStackTrace();

--- a/ngrok-java-native/src/main/java/com/ngrok/NativeSession.java
+++ b/ngrok-java-native/src/main/java/com/ngrok/NativeSession.java
@@ -7,7 +7,7 @@ public class NativeSession implements Session {
     private static String version = "0.0.0-UNKNOWN";
 
     static {
-        Runtime.Logger logger = Runtime.Logger.Get();
+        Runtime.Logger logger = Runtime.getLogger();
         try {
             Runtime.load();
             Runtime.init(logger);

--- a/ngrok-java-native/src/main/java/com/ngrok/Runtime.java
+++ b/ngrok-java-native/src/main/java/com/ngrok/Runtime.java
@@ -11,6 +11,12 @@ import java.util.Locale;
 
 class Runtime {
 
+    private static final Logger LOGGER = new Logger(); 
+
+    public static Logger getLogger() {
+        return LOGGER;
+    }
+
     private static String getLibname() {
         // TODO better logic here/use lib
         var osname = System.getProperty("os.name").toLowerCase(Locale.ENGLISH);
@@ -70,24 +76,25 @@ class Runtime {
         private static final org.slf4j.Logger logger = LoggerFactory.getLogger(Runtime.class);
         private static final String format = "[{}] {}";
 
-        private static Logger instance;
-
         private Logger() { }
-
-        public static Logger Get() {
-            if (instance == null) {
-                instance = new Logger();                
-            }
-            return instance;
-        }
 
         public String getLevel() {
             Level logLevel = Level.INFO;
-            // Iterate through levels from highest to lowest severity; stop when we find the highest enabled
-            for (Level level : Level.values()) {
-                if (logger.isEnabledForLevel(level)) {
-                    logLevel = level;
-                }
+            
+            if (logger.isErrorEnabled()) {
+                logLevel = Level.ERROR;
+            }
+            else if (logger.isWarnEnabled()) {
+                logLevel = Level.WARN;
+            }
+            else if (logger.isInfoEnabled()) {
+                logLevel = Level.INFO;
+            }
+            else if (logger.isDebugEnabled()) {
+                logLevel = Level.DEBUG;
+            }
+            else if (logger.isTraceEnabled()) {
+                logLevel = Level.TRACE;
             }
 
             return logLevel.toString();

--- a/ngrok-java-native/src/main/java/com/ngrok/Runtime.java
+++ b/ngrok-java-native/src/main/java/com/ngrok/Runtime.java
@@ -80,21 +80,12 @@ class Runtime {
 
         public String getLevel() {
             Level logLevel = Level.INFO;
-            
-            if (logger.isErrorEnabled()) {
-                logLevel = Level.ERROR;
-            }
-            else if (logger.isWarnEnabled()) {
-                logLevel = Level.WARN;
-            }
-            else if (logger.isInfoEnabled()) {
-                logLevel = Level.INFO;
-            }
-            else if (logger.isDebugEnabled()) {
-                logLevel = Level.DEBUG;
-            }
-            else if (logger.isTraceEnabled()) {
-                logLevel = Level.TRACE;
+
+            Level[] levels = new Level[] {Level.ERROR, Level.WARN, Level.INFO, Level.DEBUG, Level.TRACE};
+            for (Level level : levels) {
+                if (logger.isEnabledForLevel(level)) {
+                    logLevel = level;
+                }
             }
 
             return logLevel.toString();

--- a/ngrok-java-native/src/main/java/com/ngrok/Runtime.java
+++ b/ngrok-java-native/src/main/java/com/ngrok/Runtime.java
@@ -1,6 +1,7 @@
 package com.ngrok;
 
 import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
 
 import java.io.File;
 import java.io.IOException;
@@ -34,10 +35,7 @@ class Runtime {
         File temp = new File(temporaryDir, filename);
         try (InputStream is = Runtime.class.getResourceAsStream("/" + filename)) {
             Files.copy(is, temp.toPath(), StandardCopyOption.REPLACE_EXISTING);
-        } catch (IOException e) {
-            temp.delete();
-            throw new RuntimeException(e);
-        } catch (NullPointerException e) {
+        } catch (IOException | NullPointerException e) {
             temp.delete();
             throw new RuntimeException(e);
         }
@@ -70,17 +68,26 @@ class Runtime {
     static native void init(Logger logger);
 
     static class Logger {
+
         private static final String format = "[{}] {}";
 
+        private final Level level;
+
+        public Logger(Level level) {
+            this.level = level;
+        }
+
+        public Logger() {
+            this(Level.INFO);
+        }
+
+        public String getLevelStr() {
+            return level.toString();
+        }
+
         public void log(String level, String target, String message) {
-            switch (level) {
-                case "TRACE" -> logger.trace(format, target, message);
-                case "DEBUG" -> logger.debug(format, target, message);
-                case "INFO" -> logger.info(format, target, message);
-                case "WARN" -> logger.warn(format, target, message);
-                case "ERROR" -> logger.error(format, target, message);
-                default -> logger.debug("{}: [{}] {}", level, target, message);
-            }
+            Level lvl = Level.valueOf(level); 
+            logger.atLevel(lvl).log(format, target, message);
         }
     }
 }

--- a/ngrok-java-native/src/main/java/com/ngrok/Runtime.java
+++ b/ngrok-java-native/src/main/java/com/ngrok/Runtime.java
@@ -10,7 +10,6 @@ import java.nio.file.*;
 import java.util.Locale;
 
 class Runtime {
-    private static final org.slf4j.Logger logger = LoggerFactory.getLogger(Runtime.class);
 
     private static String getLibname() {
         // TODO better logic here/use lib
@@ -68,17 +67,29 @@ class Runtime {
     static native void init(Logger logger);
 
     static class Logger {
-
+        private static final org.slf4j.Logger logger = LoggerFactory.getLogger(Runtime.class);
         private static final String format = "[{}] {}";
 
+        private static Logger instance;
         private final Level level;
 
-        public Logger(Level level) {
+        private Logger(Level level) {
             this.level = level;
         }
 
-        public Logger() {
-            this(Level.INFO);
+        public static Logger Get() {
+            if (instance == null) {
+                String logLevel = System.getenv("NGROK_LOG_LEVEL");
+                // Default to INFO if no log level is set
+                Level level = Level.INFO;
+                if (logLevel != null) {
+                    try {
+                        level = Level.valueOf(logLevel);
+                    } catch (IllegalArgumentException ignore) {}
+                }
+                instance = new Logger(level);
+            }
+            return instance;
         }
 
         public String getLevelStr() {
@@ -86,7 +97,7 @@ class Runtime {
         }
 
         public void log(String level, String target, String message) {
-            Level lvl = Level.valueOf(level); 
+            Level lvl = Level.valueOf(level.toUpperCase()); 
             logger.atLevel(lvl).log(format, target, message);
         }
     }

--- a/ngrok-java-native/src/main/java/com/ngrok/Runtime.java
+++ b/ngrok-java-native/src/main/java/com/ngrok/Runtime.java
@@ -71,29 +71,26 @@ class Runtime {
         private static final String format = "[{}] {}";
 
         private static Logger instance;
-        private final Level level;
 
-        private Logger(Level level) {
-            this.level = level;
-        }
+        private Logger() { }
 
         public static Logger Get() {
             if (instance == null) {
-                String logLevel = System.getenv("NGROK_LOG_LEVEL");
-                // Default to INFO if no log level is set
-                Level level = Level.INFO;
-                if (logLevel != null) {
-                    try {
-                        level = Level.valueOf(logLevel);
-                    } catch (IllegalArgumentException ignore) {}
-                }
-                instance = new Logger(level);
+                instance = new Logger();                
             }
             return instance;
         }
 
-        public String getLevelStr() {
-            return level.toString();
+        public String getLevel() {
+            Level logLevel = Level.INFO;
+            // Iterate through levels from highest to lowest severity; stop when we find the highest enabled
+            for (Level level : Level.values()) {
+                if (logger.isEnabledForLevel(level)) {
+                    logLevel = level;
+                }
+            }
+
+            return logLevel.toString();
         }
 
         public void log(String level, String target, String message) {

--- a/ngrok-java-native/src/test/java/com/ngrok/DataTest.java
+++ b/ngrok-java-native/src/test/java/com/ngrok/DataTest.java
@@ -1,5 +1,6 @@
 package com.ngrok;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
@@ -7,6 +8,13 @@ import java.nio.ByteBuffer;
 import static org.junit.Assert.*;
 
 public class DataTest {
+
+    @Before
+    public void setup() {
+        // Set at "trace" level to do no filtering from Java side.
+        System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", "trace");
+    }
+
     @Test
     public void testSessionClose() throws Exception {
         try (var session = Session.connect(Session.newBuilder().metadata("java-session"))) {
@@ -19,7 +27,7 @@ public class DataTest {
         try (var session = Session.connect(Session.newBuilder());
             var tunnel = session.httpTunnel(new HttpTunnel.Builder().metadata("java-tunnel"))) {
             assertEquals("java-tunnel", tunnel.getMetadata());
-            System.out.println(tunnel.getUrl());
+            Runtime.Logger.Get().log("info", "session", tunnel.getUrl());
         }
     }
 

--- a/ngrok-java-native/src/test/java/com/ngrok/DataTest.java
+++ b/ngrok-java-native/src/test/java/com/ngrok/DataTest.java
@@ -26,7 +26,7 @@ public class DataTest {
         try (var session = Session.connect(Session.newBuilder());
             var tunnel = session.httpTunnel(new HttpTunnel.Builder().metadata("java-tunnel"))) {
             assertEquals("java-tunnel", tunnel.getMetadata());
-            Runtime.Logger.Get().log("info", "session", tunnel.getUrl());
+            Runtime.getLogger().log("info", "session", tunnel.getUrl());
         }
     }
 

--- a/ngrok-java-native/src/test/java/com/ngrok/DataTest.java
+++ b/ngrok-java-native/src/test/java/com/ngrok/DataTest.java
@@ -11,7 +11,6 @@ public class DataTest {
 
     @Before
     public void setup() {
-        // Set at "trace" level to do no filtering from Java side.
         System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", "trace");
     }
 

--- a/ngrok-java-native/src/test/java/com/ngrok/DataTest.java
+++ b/ngrok-java-native/src/test/java/com/ngrok/DataTest.java
@@ -11,7 +11,8 @@ public class DataTest {
 
     @Before
     public void setup() {
-        System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", "trace");
+        System.setProperty("org.slf4j.simpleLogger.log.com.ngrok.Runtime", "trace");
+
     }
 
     @Test

--- a/ngrok-java-native/src/test/java/com/ngrok/ForwardTest.java
+++ b/ngrok-java-native/src/test/java/com/ngrok/ForwardTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class ForwardTest {
+    // @Test
     public void testForward() throws Exception {
         var session = Session.connect(Session.newBuilder());
         assertNotNull(session);


### PR DESCRIPTION
Resolves https://github.com/ngrok-private/ngrok/issues/16140

**What**
- Configured logging level will now be used to filter log output from native Rust code.

**How**
- Log level configuration is loaded by Rust linker middleware and passed to `tracing_subscriber`.

**Validation**

Default logging configured with `TRACE`:
```
...
[Thread-1] TRACE com.ngrok.Runtime - [muxado::session] sending frame to remote
[main] TRACE com.ngrok.Runtime - [log] calling unchecked jni method: ExceptionCheck
[main] TRACE com.ngrok.Runtime - [log] looking up jni method ExceptionCheck
[main] TRACE com.ngrok.Runtime - [log] found jni method
[Thread-1] TRACE com.ngrok.Runtime - [tokio_util::codec::framed_impl] flushing framed transport
[main] TRACE com.ngrok.Runtime - [log] no exception found
[main] TRACE com.ngrok.Runtime - [log] calling checked jni method: GetMethodID
[main] TRACE com.ngrok.Runtime - [log] looking up jni method GetMethodID
[Thread-1] TRACE com.ngrok.Runtime - [tokio_util::codec::framed_impl] writing;
[main] TRACE com.ngrok.Runtime - [log] found jni method
[main] TRACE com.ngrok.Runtime - [log] checking for exception
[Thread-1] TRACE com.ngrok.Runtime - [tokio_util::codec::framed_impl] framed transport flushed
[main] TRACE com.ngrok.Runtime - [log] calling unchecked jni method: ExceptionCheck
[main] TRACE com.ngrok.Runtime - [log] looking up jni method ExceptionCheck
[Thread-1] TRACE com.ngrok.Runtime - [muxado::session] sending frame to remote
[main] TRACE com.ngrok.Runtime - [log] found jni method
[Thread-1] TRACE com.ngrok.Runtime - [tokio_util::codec::framed_impl] flushing framed transport
[Thread-1] TRACE com.ngrok.Runtime - [tokio_util::codec::framed_impl] writing;
...
```

Configured with `DEBUG`:
```
...
[main] DEBUG com.ngrok.Runtime - [log] add_parsable_certificates processed 1 valid and 0 invalid certs
[main] DEBUG com.ngrok.Runtime - [log] No cached session for DnsName(DnsName(DnsName("tunnel.ngrok.com")))
[main] DEBUG com.ngrok.Runtime - [log] Not resuming any session
[main] DEBUG com.ngrok.Runtime - [log] Using ciphersuite TLS13_AES_128_GCM_SHA256
[main] DEBUG com.ngrok.Runtime - [log] Not resuming
[main] DEBUG com.ngrok.Runtime - [log] TLS1.3 encrypted extensions: []
[main] DEBUG com.ngrok.Runtime - [log] ALPN protocol is None
[main] DEBUG com.ngrok.Runtime - [log] Ticket saved
[Thread-0] DEBUG com.ngrok.Runtime - [muxado::heartbeat] sending heartbeat
[Thread-0] DEBUG com.ngrok.Runtime - [muxado::heartbeat] waiting for response
[main] DEBUG com.ngrok.Runtime - [ngrok::internals::raw_session] decoded rpc response
[Thread-1] DEBUG com.ngrok.Runtime - [muxado::heartbeat] got response
[Thread-0] DEBUG com.ngrok.Runtime - [muxado::stream_manager] got none from stream, trying to send a fin
[Thread-0] DEBUG com.ngrok.Runtime - [muxado::stream_manager] removing stream and sending fin
[Thread-1] DEBUG com.ngrok.Runtime - [muxado::typed] read stream type
[main] DEBUG com.ngrok.Runtime - [ngrok::internals::raw_session] decoded rpc response
[Thread-2] DEBUG com.ngrok.Runtime - [muxado::stream_manager] got none from stream, trying to send a fin
[Thread-2] DEBUG com.ngrok.Runtime - [muxado::stream_manager] removing stream and sending fin
[main] DEBUG com.ngrok.Runtime - [ngrok::internals::raw_session] decoded rpc response
[Thread-2] DEBUG com.ngrok.Runtime - [muxado::stream_manager] got none from stream, trying to send a fin
[Thread-2] DEBUG com.ngrok.Runtime - [muxado::stream_manager] removing stream and sending fin
[Thread-1] DEBUG com.ngrok.Runtime - [ngrok::internals::raw_session] decoded rpc error response
[Thread-1] DEBUG com.ngrok.Runtime - [muxado::session] write_task exited
[Thread-2] DEBUG com.ngrok.Runtime - [muxado::heartbeat] requester exited
[Thread-0] DEBUG com.ngrok.Runtime - [muxado::heartbeat] heartbeat responder exiting
[Thread-3] DEBUG com.ngrok.Runtime - [muxado::heartbeat] check exited
[main] DEBUG com.ngrok.Runtime - [log] add_parsable_certificates processed 1 valid and 0 invalid certs
[main] DEBUG com.ngrok.Runtime - [log] No cached session for DnsName(DnsName(DnsName("tunnel.ngrok.com")))
[main] DEBUG com.ngrok.Runtime - [log] Not resuming any session
[main] DEBUG com.ngrok.Runtime - [log] Using ciphersuite TLS13_AES_128_GCM_SHA256
[main] DEBUG com.ngrok.Runtime - [log] Not resuming
[main] DEBUG com.ngrok.Runtime - [log] TLS1.3 encrypted extensions: []
[main] DEBUG com.ngrok.Runtime - [log] ALPN protocol is None
[main] DEBUG com.ngrok.Runtime - [log] Ticket saved
[Thread-4] DEBUG com.ngrok.Runtime - [muxado::heartbeat] sending heartbeat
[Thread-4] DEBUG com.ngrok.Runtime - [muxado::heartbeat] waiting for response
[Thread-0] DEBUG com.ngrok.Runtime - [muxado::heartbeat] got response
[main] DEBUG com.ngrok.Runtime - [ngrok::internals::raw_session] decoded rpc response
[Thread-0] DEBUG com.ngrok.Runtime - [muxado::stream_manager] got none from stream, trying to send a fin
[Thread-0] DEBUG com.ngrok.Runtime - [muxado::stream_manager] removing stream and sending fin
[Thread-2] DEBUG com.ngrok.Runtime - [muxado::typed] read stream type
[Thread-0] DEBUG com.ngrok.Runtime - [muxado::session] write_task exited
[Thread-4] DEBUG com.ngrok.Runtime - [muxado::heartbeat] heartbeat responder exiting
[Thread-2] DEBUG com.ngrok.Runtime - [muxado::heartbeat] check exited
[Thread-1] DEBUG com.ngrok.Runtime - [muxado::heartbeat] requester exited
...
```

Configured with `INFO`:
```
[main] INFO com.ngrok.Runtime - [session] https://38fe-73-169-116-49.ngrok.io
```
