### PR TITLE
Allow overriding of connection socket buffer size

### DIFF
--- a/ngrok-java/src/main/java/com/ngrok/net/ConnectionSocket.java
+++ b/ngrok-java/src/main/java/com/ngrok/net/ConnectionSocket.java
@@ -5,8 +5,8 @@ import java.net.InetAddress;
 import java.net.Socket;
 
 public class ConnectionSocket extends Socket {
-    protected ConnectionSocket() throws IOException {
-        super(new ConnectionSocketImpl());
+    protected ConnectionSocket(int bufferSize) throws IOException {
+        super(new ConnectionSocketImpl(bufferSize));
     }
 
     @Override

--- a/ngrok-java/src/main/java/com/ngrok/net/ConnectionSocketImpl.java
+++ b/ngrok-java/src/main/java/com/ngrok/net/ConnectionSocketImpl.java
@@ -8,8 +8,10 @@ import java.io.OutputStream;
 
 public class ConnectionSocketImpl extends AbstractSocketImpl {
     protected Connection connection;
+    protected int bufferSize;
 
-    protected ConnectionSocketImpl() {
+    protected ConnectionSocketImpl(int bufferSize) {
+        this.bufferSize = bufferSize;
     }
 
     protected void setConnection(Connection connection) {
@@ -22,11 +24,11 @@ public class ConnectionSocketImpl extends AbstractSocketImpl {
 
     @Override
     protected InputStream getInputStream() throws IOException {
-        return new ConnectionInputStream(connection, 1024);
+        return new ConnectionInputStream(connection, bufferSize);
     }
 
     @Override
     protected OutputStream getOutputStream() throws IOException {
-        return new ConnectionOutputStream(connection, 1024);
+        return new ConnectionOutputStream(connection, bufferSize);
     }
 }

--- a/ngrok-java/src/main/java/com/ngrok/net/TunnelServerSocket.java
+++ b/ngrok-java/src/main/java/com/ngrok/net/TunnelServerSocket.java
@@ -8,14 +8,21 @@ import java.net.Socket;
 import java.net.SocketException;
 
 public class TunnelServerSocket extends ServerSocket {
+    private final int bufferSize;
+
     public TunnelServerSocket(Tunnel tunnel) {
+        this(tunnel, 1024);
+    }
+
+    public TunnelServerSocket(Tunnel tunnel, int bufferSize) {
         super(new TunnelSocketImpl(tunnel));
+        this.bufferSize = bufferSize;
     }
 
     public Socket accept() throws IOException {
         if (isClosed())
             throw new SocketException("Socket is closed");
-        var s = new ConnectionSocket();
+        var s = new ConnectionSocket(bufferSize);
         implAccept(s);
         return s;
     }


### PR DESCRIPTION
The fixed buffer size of `1024` can cause `java.nio.BufferOverflowException` errors. This PR adds the ability to override the default buffer size.