### PR TITLE
Chunk data based on the buffer capacity

### DIFF
--- a/ngrok-java/pom.xml
+++ b/ngrok-java/pom.xml
@@ -10,4 +10,13 @@
     <artifactId>ngrok-java</artifactId>
     <name>ngrok :: Java</name>
     <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/ngrok-java/src/main/java/com/ngrok/net/ConnectionOutputStream.java
+++ b/ngrok-java/src/main/java/com/ngrok/net/ConnectionOutputStream.java
@@ -24,8 +24,11 @@ public class ConnectionOutputStream extends OutputStream {
 
     @Override
     public void write(byte[] b, int off, int len) throws IOException {
-        buffer.put(b, off, len);
-        flush();
+        for (int pos = 0, delta = Math.min(buffer.capacity(), len); pos < len; pos += delta) {
+            delta = Math.min(delta, len-pos);
+            buffer.put(b, off+pos, delta);
+            flush();
+        }
     }
 
     @Override

--- a/ngrok-java/src/main/java/com/ngrok/net/ConnectionSocketImpl.java
+++ b/ngrok-java/src/main/java/com/ngrok/net/ConnectionSocketImpl.java
@@ -22,11 +22,11 @@ public class ConnectionSocketImpl extends AbstractSocketImpl {
 
     @Override
     protected InputStream getInputStream() throws IOException {
-        return new ConnectionInputStream(connection, 1024);
+        return new ConnectionInputStream(connection, 4096);
     }
 
     @Override
     protected OutputStream getOutputStream() throws IOException {
-        return new ConnectionOutputStream(connection, 1024);
+        return new ConnectionOutputStream(connection, 4096);
     }
 }

--- a/ngrok-java/src/test/java/com/ngrok/net/ConnectionOutputStreamTest.java
+++ b/ngrok-java/src/test/java/com/ngrok/net/ConnectionOutputStreamTest.java
@@ -1,0 +1,60 @@
+package com.ngrok.net;
+
+import com.ngrok.Connection;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Random;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertFalse;
+
+public class ConnectionOutputStreamTest {
+    @Test
+    public void testStreamChunking() throws Exception {
+        var conn = new CollectingConnection();
+        var os = new ConnectionOutputStream(conn, 8);
+
+        // an array of 32 bytes
+        var data = "0123456789 0123456789 0123456789".getBytes(StandardCharsets.UTF_8);
+        assertEquals(32, data.length);
+
+        for (int low = 0; low < data.length; low++) {
+            for (int high = low; high < data.length; high++) {
+                os.write(data, low, high-low);
+                conn.data.flip();
+
+                assertEquals(high-low, conn.data.limit());
+                for (int k = low; k < high; k++) {
+                    assertEquals(data[k], conn.data.get());
+                }
+                conn.data.clear();
+            }
+        }
+    }
+
+    private static class CollectingConnection extends Connection {
+        private final ByteBuffer data = ByteBuffer.allocate(1024);
+        CollectingConnection() {
+            super("local");
+        }
+
+        @Override
+        public int read(ByteBuffer dst) throws IOException {
+            return 0;
+        }
+
+        @Override
+        public int write(ByteBuffer src) throws IOException {
+            data.put(src);
+            return src.limit();
+        }
+
+        @Override
+        public void close() throws IOException {
+
+        }
+    }
+}


### PR DESCRIPTION
Fixes: #5
Replaces: #3 

If we attempt to write an array bigger then our capacity, we should automatically split it in chunks and write these, as opposed to throwing array out of bounds exc. 

Also, increase the buffer size to 4k.