### PR TITLE
Improve artefact names most notably rename aarch64 to aarch_64

### DIFF
--- a/.github/workflows/release-perform.yml
+++ b/.github/workflows/release-perform.yml
@@ -20,7 +20,7 @@ jobs:
         config:
           - host: ubuntu-latest
             target: i686-unknown-linux-gnu
-            artifact: linux-x86
+            artifact: linux-x86_32
             linker: gcc-multilib
             pkgFlags: "--define 'skipTests'"
           - host: ubuntu-latest
@@ -28,7 +28,7 @@ jobs:
             artifact: linux-x86_64
           - host: ubuntu-latest
             target: aarch64-unknown-linux-gnu
-            artifact: linux-aarch64
+            artifact: linux-aarch_64
             linker: gcc-aarch64-linux-gnu
             pkgFlags: "--define 'skipTests'"
           - host: ubuntu-latest
@@ -38,7 +38,7 @@ jobs:
             pkgFlags: "--define 'skipTests'"
           - host: ubuntu-latest
             target: aarch64-linux-android
-            artifact: linux-android-aarch64
+            artifact: linux-android-aarch_64
             linker: gcc-aarch64-linux-gnu
             pkgFlags: "--define 'skipTests'"
           - host: windows-latest
@@ -53,7 +53,7 @@ jobs:
             artifact: osx-x86_64
           - host: macos-latest
             target: aarch64-apple-darwin
-            artifact: osx-aarch64
+            artifact: osx-aarch_64
             pkgFlags: "--define 'skipTests'"
     runs-on: ${{ matrix.config.host }}
     steps:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+.PHONY: all
+all: build
+
+.PHONY: build
+build:
+	mvn package --global-toolchains toolchains.xml
+
+.PHONY: clean
+clean:
+	mvn clean
+
+.PHONY: rebuild
+rebuild: 
+	mvn clean package --global-toolchains toolchains.xml


### PR DESCRIPTION
Currently, trying to use the instructions around automatic OS detection described in the `README.md`, results in a failing build. The [os-maven-plugin](https://github.com/trustin/os-maven-plugin) expects `aarch64` to be named `aarch_64`, and therefore cannot find the native library associated with it (for example on mac m1/m2). 

Change the artifact names to `aarch_64` where relevant.