### PR TITLE
Expose session close tunnel api

### DIFF
--- a/ngrok-java-native/src/lib.rs
+++ b/ngrok-java-native/src/lib.rs
@@ -774,6 +774,17 @@ impl<'local> com_ngrok::NativeSessionRs<'local> for NativeSessionRsImpl<'local> 
         }
     }
 
+    fn close_tunnel(
+        &self,
+        this: ComNgrokNativeSession<'local>,
+        tunnel_id: String,
+    ) -> Result<(), jaffi_support::Error<IOExceptionErr>> {
+        let rt = RT.get().expect("runtime not initialized");
+
+        let sess: MutexGuard<Session> = self.get_native(this);
+        rt.block_on(sess.close_tunnel(tunnel_id)).map_err(io_exc)
+    }
+
     fn close(
         &self,
         this: ComNgrokNativeSession<'local>,

--- a/ngrok-java-native/src/main/java/com/ngrok/NativeSession.java
+++ b/ngrok-java-native/src/main/java/com/ngrok/NativeSession.java
@@ -109,6 +109,15 @@ public class NativeSession implements Session {
     public native NativeLabeledTunnel labeledTunnel(NativeLabeledTunnel.Builder builder) throws IOException;
 
     /**
+     * Closes the native tunnel by ID in this session.
+     * 
+     * @param tunnelId the ID of the tunnel to close
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public native void closeTunnel(String tunnelId) throws IOException;
+
+    /**
      * Closes the native session.
      *
      * @throws IOException if an I/O error occurs

--- a/ngrok-java-native/src/test/java/com/ngrok/ForwardTest.java
+++ b/ngrok-java-native/src/test/java/com/ngrok/ForwardTest.java
@@ -14,6 +14,15 @@ public class ForwardTest {
         var tunnel = session.httpTunnel(new HttpTunnel.Builder().domain("ngrok-java-test.ngrok.io"));
         assertNotNull(tunnel);
 
+        new Thread(() -> {
+            try {
+                Thread.sleep(10000);
+                session.closeTunnel(tunnel.getId());
+            } catch(Throwable th) {
+                th.printStackTrace();
+            }
+        }).start();
+
         tunnel.forwardTcp("127.0.0.1:8000");
         assertTrue(true);
     }

--- a/ngrok-java/src/main/java/com/ngrok/Session.java
+++ b/ngrok-java/src/main/java/com/ngrok/Session.java
@@ -143,6 +143,14 @@ public interface Session extends AutoCloseable {
     public LabeledTunnel labeledTunnel(LabeledTunnel.Builder builder) throws IOException;
 
     /**
+     * Closes a tunnel by its ID.
+     * 
+     * @param tunnelId the id of the tunnel to close
+     * @throws IOException if an I/O error occurs during tunnel close
+     */
+    public void closeTunnel(String tunnelId) throws IOException;
+
+    /**
      * Configures a function which is called when the ngrok service requests that this {@link Session} stops.
      * Your application may choose to interpret this callback as a request to terminate the {@link Session} or the entire process.
      */


### PR DESCRIPTION
Allows tunnel to be closed from the outside. Once a `forwardTcp` is called on a tunnel instance, it no longer respects `close` on the tunnel itself (or allows interrupting the thread). This is an alternative, session-wide method to stop a tunnel by its id (available as `getId` method).