### PR TITLE
Use last column to parse remote address

### DIFF
--- a/ngrok-java/src/main/java/com/ngrok/Connection.java
+++ b/ngrok-java/src/main/java/com/ngrok/Connection.java
@@ -21,8 +21,11 @@ public interface Connection extends AutoCloseable {
      * @return {@link InetSocketAddress} representing the internet address
      */
     default InetSocketAddress inetAddress() {
-        var parts = getRemoteAddr().split(":");
-        return new InetSocketAddress(parts[0], Integer.parseInt(parts[1]));
+        var addr = getRemoteAddr();
+        var lastColumn = addr.lastIndexOf(":");
+        var host = addr.substring(0, lastColumn);
+        var port = addr.substring(lastColumn + 1);
+        return new InetSocketAddress(host, Integer.parseInt(port));
     }
 
     /**

--- a/ngrok-java/src/test/java/com/ngrok/ConnectionTest.java
+++ b/ngrok-java/src/test/java/com/ngrok/ConnectionTest.java
@@ -1,0 +1,53 @@
+package com.ngrok;
+
+import com.ngrok.Connection;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class ConnectionTest {
+    @Test
+    public void testInetAddress() throws Exception {
+        var conn = new ConnectionAddressMock();
+
+        conn.remoteAddr = "4.3.2.1:8000";
+        var addr = conn.inetAddress();
+        assertNotNull(addr);
+        assertEquals("4.3.2.1", addr.getHostName());
+        assertEquals(8000, addr.getPort());
+
+        conn.remoteAddr = "[2a00:23c8:a8dd:e501:b02c:ea1a:83cf:395e]:64440";
+        addr = conn.inetAddress();
+        assertNotNull(addr);
+        assertEquals("2a00:23c8:a8dd:e501:b02c:ea1a:83cf:395e", addr.getHostName());
+        assertEquals(64440, addr.getPort());
+    }
+
+    class ConnectionAddressMock implements Connection {
+        String remoteAddr;
+
+        @Override
+        public String getRemoteAddr() {
+            return remoteAddr;
+        }
+
+        @Override
+        public int read(ByteBuffer dst) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int write(ByteBuffer src) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void close() throws IOException {
+            throw new UnsupportedOperationException();
+        }
+    }
+}


### PR DESCRIPTION
Resolves: #30 

Use the last column to split host/port, instead of the first one, which fails in case of ipv6 address.