### PR TITLE
exclude native impl javadocs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
           distribution: "temurin"
           cache: "maven"
       - name: Build Javadocs
-        run: mvn javadoc:aggregate
+        run: mvn javadoc:aggregate -Dmaven.javadoc.skippedModules=ngrok-java-native
       - name: Archive Javadoc site
         run: tar --directory target/site/apidocs -cvf "$RUNNER_TEMP/artifact.tar" .
       - name: Upload Archive

--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,7 @@ install:
 .PHONY: reinstall
 reinstall:
 	mvn clean install --global-toolchains toolchains.xml
+
+.PHONY: javadoc
+javadoc:
+	mvn javadoc:aggregate --global-toolchains toolchains.xml -Dmaven.javadoc.skippedModules=ngrok-java-native


### PR DESCRIPTION
The native package javadocs are implementation detail, so exclude them from the official docs.