### PR TITLE
add TrafficPolicy, remap Policy -> TrafficPolicy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,14 @@ jobs:
         env:
           NGROK_AUTHTOKEN: ${{ secrets.NGROK_AUTHTOKEN }}
 
-  build-glibc-2_24:
-    name: Build Ngrok Java (glibc 2.24)
+  # We need to target older glibc (as old as possible) to support customers on very old Linux versions. 
+  # If we end up needing to target older than 2.8, we will have to do a special workaround, as actions/checkout 
+  # won't work without newer glibc versions:
+  # https://github.com/actions/checkout/issues/1809
+  build-glibc-2_28:
+    name: Build Ngrok Java (glibc 2.28)
     runs-on: ubuntu-latest
-    container: quay.io/pypa/manylinux_2_24_x86_64
+    container: quay.io/pypa/manylinux_2_28_x86_64
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/release-perform.yml
+++ b/.github/workflows/release-perform.yml
@@ -26,7 +26,7 @@ jobs:
           - host: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             artifact: linux-x86_64
-            container: quay.io/pypa/manylinux_2_24_x86_64
+            container: quay.io/pypa/manylinux_2_28_x86_64
           - host: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             artifact: linux-aarch_64

--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,7 @@
           "rust-src"
           "rustc"
           "rustfmt"
+          "rust-analyzer"
         ];
         java-toolchain = with pkgs; [
           openjdk17_headless

--- a/ngrok-java-native/Cargo.lock
+++ b/ngrok-java-native/Cargo.lock
@@ -18,17 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
-name = "async-rustls"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93b21a03b7c21702a0110f9f8d228763a533570deb376119042dabf33c37a01a"
-dependencies = [
- "futures-io",
- "rustls 0.20.8",
- "webpki 0.22.0",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -65,15 +54,27 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.0"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "block-buffer"
@@ -102,15 +103,15 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cb5eea41dce128eb8257a90648a2392b0ec58a4bc9fcfa5d97e3e79abc7c020"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cesu8",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "2aba8f4e9906c7ce3c73463f62a7f0c65183ada1a2d47e397cc8810827f9694f"
 
 [[package]]
 name = "cesu8"
@@ -181,7 +182,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1a816186fa68d9e426e3cb4ae4dff1fcd8e4a2c34b781bf7a822574a0d0aac8"
 dependencies = [
- "sct 0.6.1",
+ "sct",
 ]
 
 [[package]]
@@ -293,6 +294,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-rustls"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d8a2499f0fecc0492eb3e47eab4e92da7875e1028ad2528f214ac3346ca04e"
+dependencies = [
+ "futures-io",
+ "rustls 0.22.4",
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,9 +355,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.9"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -359,7 +371,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
 dependencies = [
  "base64 0.13.1",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "headers-core",
  "http",
@@ -476,7 +488,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki 0.21.4",
+ "webpki",
 ]
 
 [[package]]
@@ -493,7 +505,7 @@ dependencies = [
  "rustls-native-certs 0.5.0",
  "tokio",
  "tokio-rustls",
- "webpki 0.21.4",
+ "webpki",
 ]
 
 [[package]]
@@ -573,9 +585,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.141"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "lock_api"
@@ -643,7 +655,7 @@ checksum = "e92b89ac3127251efde6f5a9586e5aae99468d06fcf9f133b377f58d5ed66446"
 dependencies = [
  "async-trait",
  "awaitdrop",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "futures",
  "pin-project",
@@ -656,17 +668,18 @@ dependencies = [
 
 [[package]]
 name = "ngrok"
-version = "0.14.0-pre.10"
+version = "0.14.0-pre.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dadbf3b49cd817aa6c8364bafb25a3c3f0664185b3c85e43facd53f60adcfb9"
+checksum = "83a8b346f2afafd32076a1a63698c185ec18c5ff3a3c58a6eb1283e94eece59e"
 dependencies = [
  "arc-swap",
- "async-rustls",
  "async-trait",
  "awaitdrop",
- "base64 0.13.1",
+ "base64 0.21.7",
+ "bitflags 2.6.0",
  "bytes",
  "futures",
+ "futures-rustls",
  "hostname",
  "hyper",
  "hyper-proxy",
@@ -676,7 +689,7 @@ dependencies = [
  "pin-project",
  "proxy-protocol",
  "regex",
- "rustls-native-certs 0.6.3",
+ "rustls-native-certs 0.7.1",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -876,7 +889,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -914,10 +927,25 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin",
- "untrusted",
+ "spin 0.5.2",
+ "untrusted 0.7.1",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if 1.0.0",
+ "getrandom",
+ "libc",
+ "spin 0.9.8",
+ "untrusted 0.9.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -928,21 +956,22 @@ checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
 dependencies = [
  "base64 0.13.1",
  "log",
- "ring",
- "sct 0.6.1",
- "webpki 0.21.4",
+ "ring 0.16.20",
+ "sct",
+ "webpki",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.20.8"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
 dependencies = [
- "log",
- "ring",
- "sct 0.7.0",
- "webpki 0.22.0",
+ "ring 0.17.8",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -959,23 +988,42 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.6.3"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+checksum = "a88d6d420651b496bdd98684116959239430022a115c1240e6c3993be0b15fba"
 dependencies = [
  "openssl-probe",
  "rustls-pemfile",
+ "rustls-pki-types",
  "schannel",
  "security-framework",
 ]
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.2"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.22.1",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e"
+dependencies = [
+ "ring 0.17.8",
+ "rustls-pki-types",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -1014,18 +1062,8 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
 dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "sct"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
-dependencies = [
- "ring",
- "untrusted",
+ "ring 0.16.20",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
@@ -1034,7 +1072,7 @@ version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -1173,6 +1211,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1288,7 +1338,7 @@ checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
 dependencies = [
  "rustls 0.19.1",
  "tokio",
- "webpki 0.21.4",
+ "webpki",
 ]
 
 [[package]]
@@ -1437,6 +1487,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1554,18 +1610,8 @@ version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
 dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "webpki"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
-dependencies = [
- "ring",
- "untrusted",
+ "ring 0.16.20",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
@@ -1618,6 +1664,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1648,6 +1703,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1658,6 +1729,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1672,6 +1749,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1682,6 +1765,18 @@ name = "windows_i686_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1696,6 +1791,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1706,6 +1807,12 @@ name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1720,6 +1827,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1730,3 +1843,15 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/ngrok-java-native/Cargo.toml
+++ b/ngrok-java-native/Cargo.toml
@@ -13,7 +13,7 @@ jaffi_support = "0.2.0"
 once_cell = "1.17.1"
 futures = "0.3.25"
 bytes = "1.4.0"
-ngrok = "0.14.0-pre.10"
+ngrok = "0.14.0-pre.14"
 tokio = { version = "1.26.0", features = ["full"] }
 async-trait = "0.1.59"
 tracing = "0.1.37"

--- a/ngrok-java-native/src/lib.rs
+++ b/ngrok-java-native/src/lib.rs
@@ -470,7 +470,11 @@ impl<'local> NativeSessionRsImpl<'local> {
         bldr.proxy_proto(ProxyProto::from(jeb.get_proxy_proto_version(self.env)));
 
         if let Some(policy) = jeb.get_policy(self.env).of_string(self.env) {
-            bldr.policy(policy.as_str()).map_err(io_exc)?;
+            bldr.traffic_policy(policy.as_str());
+        }
+
+        if let Some(traffic_policy) = jeb.get_traffic_policy(self.env).of_string(self.env) {
+            bldr.traffic_policy(traffic_policy);
         }
 
         // from TcpBuilder
@@ -514,7 +518,11 @@ impl<'local> NativeSessionRsImpl<'local> {
         bldr.proxy_proto(ProxyProto::from(jeb.get_proxy_proto_version(self.env)));
 
         if let Some(policy) = jeb.get_policy(self.env).of_string(self.env) {
-            bldr.policy(policy.as_str()).map_err(io_exc)?;
+            bldr.traffic_policy(policy.as_str());
+        }
+
+        if let Some(traffic_policy) = jeb.get_traffic_policy(self.env).of_string(self.env) {
+            bldr.traffic_policy(traffic_policy);
         }
 
         // from TlsBuilder
@@ -580,7 +588,11 @@ impl<'local> NativeSessionRsImpl<'local> {
         bldr.proxy_proto(ProxyProto::from(jeb.get_proxy_proto_version(self.env)));
 
         if let Some(policy) = jeb.get_policy(self.env).of_string(self.env) {
-            bldr.policy(policy.as_str()).map_err(io_exc)?;
+            bldr.traffic_policy(policy.as_str());
+        }
+
+        if let Some(traffic_policy) = jeb.get_traffic_policy(self.env).of_string(self.env) {
+            bldr.traffic_policy(traffic_policy);
         }
 
         // from HttpBuilder

--- a/ngrok-java-native/src/test/java/com/ngrok/DataTest.java
+++ b/ngrok-java-native/src/test/java/com/ngrok/DataTest.java
@@ -60,4 +60,16 @@ public class DataTest {
             Runtime.getLogger().log("info", "session", listener.getUrl());
         }
     }
+
+    @Test
+    public void testTrafficPolicy() throws Exception {
+        final ClassLoader classLoader = getClass().getClassLoader();
+        final String trafficPolicy = new String(classLoader.getResourceAsStream("policy.json").readAllBytes());
+
+        try (var session = Session.withAuthtokenFromEnv().connect();
+                var listener = session.httpEndpoint().metadata("java-endpoint").trafficPolicy(trafficPolicy).listen()) {
+            assertEquals("java-endpoint", listener.getMetadata());
+            Runtime.getLogger().log("info", "session", listener.getUrl());
+        }
+    }
 }

--- a/ngrok-java/src/main/java/com/ngrok/EndpointBuilder.java
+++ b/ngrok-java/src/main/java/com/ngrok/EndpointBuilder.java
@@ -14,7 +14,7 @@ public abstract class EndpointBuilder<T extends EndpointBuilder<T>> extends Meta
     private final List<String> allowCIDR = new ArrayList<>();
     private final List<String> denyCIDR = new ArrayList<>();
     private ProxyProto proxyProto = ProxyProto.None;
-    private Optional<String> policy = Optional.empty();
+    private Optional<String> trafficPolicy = Optional.empty();
 
     /**
      * Adds a CIDR to the list of allowed CIDRs for this endpoint.
@@ -60,13 +60,24 @@ public abstract class EndpointBuilder<T extends EndpointBuilder<T>> extends Meta
     }
 
     /**
-     * Sets the policy for this endpoint.
+     * DEPRECATED: use trafficPolicy instead.
      *
      * @param policy the policy for the builder
      * @return An instance the builder represented by type T
      */
     public T policy(final String policy) {
-        this.policy = Optional.ofNullable(policy);
+        this.trafficPolicy = Optional.ofNullable(policy);
+        return (T) this;
+    }
+
+    /**
+     * Sets the policy for this endpoint.
+     *
+     * @param trafficPolicy the policy for the builder
+     * @return An instance the builder represented by type T
+     */
+    public T trafficPolicy(final String trafficPolicy) {
+        this.trafficPolicy = Optional.ofNullable(trafficPolicy);
         return (T) this;
     }
 
@@ -107,11 +118,20 @@ public abstract class EndpointBuilder<T extends EndpointBuilder<T>> extends Meta
     }
 
     /**
-     * Returns the policy for this endpoint.
+     * DEPRECATED: use getTrafficPolicy instead.
      *
      * @return the currently set policy
      */
     public Optional<String> getPolicy() {
-        return this.policy;
+        return this.trafficPolicy;
+    }
+
+    /**
+     * Returns the policy for this endpoint.
+     *
+     * @return the currently set policy
+     */
+    public Optional<String> getTrafficPolicy() {
+        return this.trafficPolicy;
     }
 }


### PR DESCRIPTION
### Why 
Currently, we are in the process of erasing strict policy types from our SDKs. This changes makes sure policy is sent to the backend as a traffic_policy string as opposed to a strictly formatted policy struct.

### How
The traffic policy field already exists and functions in the underlying rust SDK. So all we have to do is plumb the new field through to Rust. Additionally, instances of Policy are remapped to traffic policy.

### Validation
Current unit tests continue to run.
An additional unit test was added using the new TrafficPolicy field.

### Additional Changes

#### Rust LSP
To make development easier, I added the rust SDK to our nix flake.

#### Bumping glibc to 2.28 in workflows
In our CI, we target/build against older versions of glibc to support customers on very old Linux. However, the checkout action provided by github has recently upgraded to Node 20, which needs a newer version than what we were targeting. For now, we are simply updating our version. However, if we end up needing to target older than 2.8, we will have to do a special workaround, as actions/checkout won't work without newer glibc versions.

Context: https://github.com/actions/checkout/issues/1809
