### PR TITLE
bump the android abi version for the C linker we're looking for when cross-compiling

### DIFF
--- a/.github/workflows/release-perform.yml
+++ b/.github/workflows/release-perform.yml
@@ -88,7 +88,7 @@ jobs:
           if [[ "$adjusted_target" == *"aarch64"* ]]; then
             compiler="aarch64-linux-android21-clang"
           else
-            compiler="armv7a-linux-androideabi19-clang"
+            compiler="armv7a-linux-androideabi21-clang"
           fi
 
           echo "CC_${adjusted_target}=${ndk_root}/${compiler}" >> $GITHUB_ENV


### PR DESCRIPTION
This should hopefully fix the failing android builds in the release pipeline :crossed_fingers: 