### PR TITLE
Fix/android 16kb alignment

### DIFF
--- a/ngrok-java-native/.cargo/config.toml
+++ b/ngrok-java-native/.cargo/config.toml
@@ -1,5 +1,8 @@
+[build]
+rustflags = ["-A", "dead_code", "-A", "mismatched_lifetime_syntaxes"]
+
 [target.aarch64-linux-android]
-rustflags = ["-C", "link-arg=-z", "-C", "link-arg=max-page-size=16384"]
+rustflags = ["-C", "link-arg=-z", "-C", "link-arg=max-page-size=16384", "-A", "dead_code", "-A", "mismatched_lifetime_syntaxes"]
 
 [target.x86_64-linux-android]
-rustflags = ["-C", "link-arg=-z", "-C", "link-arg=max-page-size=16384"]
+rustflags = ["-C", "link-arg=-z", "-C", "link-arg=max-page-size=16384", "-A", "dead_code", "-A", "mismatched_lifetime_syntaxes"]

--- a/ngrok-java-native/.cargo/config.toml
+++ b/ngrok-java-native/.cargo/config.toml
@@ -1,0 +1,5 @@
+[target.aarch64-linux-android]
+rustflags = ["-C", "link-arg=-z", "-C", "link-arg=max-page-size=16384"]
+
+[target.x86_64-linux-android]
+rustflags = ["-C", "link-arg=-z", "-C", "link-arg=max-page-size=16384"]


### PR DESCRIPTION
The newer versions of Android require 16KB native libraries, this PR update the build options in cargo for ngrok-rust to produce 16kb aligned so native libraries.

In addition mute a number of warnings.

Not sure if this PR will ever be merged but it might be useful for other people facing the same issue.