### PR TITLE
fix: resolve clippy warnings from newer Rust toolchain

### DIFF
--- a/ngrok-java-native/Cargo.toml
+++ b/ngrok-java-native/Cargo.toml
@@ -21,7 +21,7 @@ tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 url = "2.4.1"
 
 [lib]
-crate_type = ["cdylib"]
+crate-type = ["cdylib"]
 
 [patch.crates-io]
 jaffi_support = { git = 'https://github.com/ngrok-oss/jaffi.git', branch = 'josh/lower-jni-version' }

--- a/ngrok-java-native/src/lib.rs
+++ b/ngrok-java-native/src/lib.rs
@@ -45,6 +45,7 @@ use ngrok::{
 
 #[allow(clippy::all)]
 #[allow(dead_code)]
+#[allow(mismatched_lifetime_syntaxes)]
 mod com_ngrok {
     include!(concat!(env!("OUT_DIR"), "/generated_jaffi.rs"));
 }
@@ -176,19 +177,6 @@ trait JNIExt<'local> {
         self.get_env()
             .take_rust_field(this, "native_address")
             .expect("cannot take native value")
-    }
-
-    fn as_string(&self, jstr: JString) -> Option<String> {
-        if jstr.is_null() {
-            None
-        } else {
-            Some(
-                self.get_env()
-                    .get_string(jstr)
-                    .expect("could not convert to string")
-                    .into(),
-            )
-        }
     }
 
     fn ngrok_exc_err<


### PR DESCRIPTION
- Allow `mismatched_lifetime_syntaxes` in generated jaffi module. These warnings come from code generated by the jaffi build dependency, not from our source, so suppressing at the include site is appropriate.
- Remove unused `JNIExt::as_string` method.
- Rename `crate_type` to `crate-type` in Cargo.toml (underscore form is deprecated and will not work in edition 2024).