### PR TITLE
ci: bump outdated actions in docs.yml

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,8 +10,8 @@ jobs:
     name: Javadocs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
           java-version: |
             17
@@ -20,14 +20,10 @@ jobs:
           cache: "maven"
       - name: Build Javadocs
         run: mvn javadoc:aggregate -Dmaven.javadoc.skippedModules=ngrok-java-native
-      - name: Archive Javadoc site
-        run: tar --directory target/site/apidocs -cvf "$RUNNER_TEMP/artifact.tar" .
-      - name: Upload Archive
-        uses: actions/upload-artifact@v1
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          name: github-pages
-          path: ${{ runner.temp }}/artifact.tar
-          retention-days: ${{ inputs.retention-days }}
+          path: target/site/apidocs
 
   deploy:
     needs: gen-javadocs
@@ -46,4 +42,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
I was so focused on `ci.yml` I forgot to check docs